### PR TITLE
Fix for the React Router issue (#29)

### DIFF
--- a/FlowerShopBackend/src/main/java/pw/se2/flowershopbackend/configs/RouterConfig.java
+++ b/FlowerShopBackend/src/main/java/pw/se2/flowershopbackend/configs/RouterConfig.java
@@ -1,0 +1,28 @@
+package pw.se2.flowershopbackend.configs;
+
+import org.springframework.boot.web.server.ErrorPage;
+import org.springframework.boot.web.server.WebServerFactoryCustomizer;
+import org.springframework.boot.web.servlet.server.ConfigurableServletWebServerFactory;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.servlet.config.annotation.ViewControllerRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class RouterConfig implements WebMvcConfigurer {
+    @Override
+    public void addViewControllers(ViewControllerRegistry registry) {
+        // Fix for React Router
+        registry.addViewController("/notFound").setViewName("forward:/index.html");
+        // Nicer handling of SwaggerUI
+        registry.addViewController("/swagger-ui").setViewName("redirect:/swagger-ui/index.html");
+    }
+
+    @Bean
+    public WebServerFactoryCustomizer<ConfigurableServletWebServerFactory> containerCustomizer() {
+        return container -> {
+            container.addErrorPages(new ErrorPage(HttpStatus.NOT_FOUND, "/notFound"));
+        };
+    }
+}


### PR DESCRIPTION
This pull request implements a fix for the react router issue described in #29. This is done by adding a custom error page for not found errors. These errors then are forwarded to index.html, so that React can handle them. 

**Note: Please make sure this won't break any API functionality that might want to throw Not Found errors!**